### PR TITLE
Add NestJS Trello skeleton

### DIFF
--- a/trello-nest/README.md
+++ b/trello-nest/README.md
@@ -1,0 +1,23 @@
+# Trello Clone with NestJS
+
+Đây là skeleton ứng dụng Trello clone sử dụng NestJS. Mã nguồn được viết bằng TypeScript với cấu trúc module đơn giản (board, column, card).
+
+## Cài đặt
+
+1. Cài Node.js >= 14 và npm.
+2. Cài dependencies:
+   ```bash
+   npm install
+   ```
+3. Chạy ứng dụng ở chế độ phát triển:
+   ```bash
+   npm run start:dev
+   ```
+
+## Cấu trúc
+
+- `src/boards`: Quản lý board
+- `src/columns`: Quản lý column thuộc board
+- `src/cards`: Quản lý card thuộc column
+
+Tất cả dữ liệu hiện đang lưu trong bộ nhớ (mảng). Bạn có thể mở rộng bằng cách kết nối với cơ sở dữ liệu thực tế.

--- a/trello-nest/nest-cli.json
+++ b/trello-nest/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/trello-nest/package.json
+++ b/trello-nest/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "trello-nest",
+  "version": "0.0.1",
+  "description": "Trello clone built with NestJS",
+  "private": true,
+  "scripts": {
+    "start": "nest start",
+    "start:dev": "nest start --watch"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@types/node": "^18.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/trello-nest/src/app.controller.ts
+++ b/trello-nest/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}

--- a/trello-nest/src/app.module.ts
+++ b/trello-nest/src/app.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { BoardsModule } from './boards/boards.module';
+import { ColumnsModule } from './columns/columns.module';
+import { CardsModule } from './cards/cards.module';
+
+@Module({
+  imports: [BoardsModule, ColumnsModule, CardsModule],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/trello-nest/src/app.service.ts
+++ b/trello-nest/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello(): string {
+    return 'Welcome to Trello Clone API';
+  }
+}

--- a/trello-nest/src/boards/boards.controller.ts
+++ b/trello-nest/src/boards/boards.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { BoardsService } from './boards.service';
+import { CreateBoardDto } from './dto/create-board.dto';
+
+@Controller('boards')
+export class BoardsController {
+  constructor(private readonly boardsService: BoardsService) {}
+
+  @Get()
+  findAll() {
+    return this.boardsService.findAll();
+  }
+
+  @Post()
+  create(@Body() dto: CreateBoardDto) {
+    return this.boardsService.create(dto);
+  }
+}

--- a/trello-nest/src/boards/boards.module.ts
+++ b/trello-nest/src/boards/boards.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { BoardsController } from './boards.controller';
+import { BoardsService } from './boards.service';
+
+@Module({
+  controllers: [BoardsController],
+  providers: [BoardsService],
+  exports: [BoardsService],
+})
+export class BoardsModule {}

--- a/trello-nest/src/boards/boards.service.ts
+++ b/trello-nest/src/boards/boards.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { CreateBoardDto } from './dto/create-board.dto';
+
+@Injectable()
+export class BoardsService {
+  private boards = [] as { id: number; title: string }[];
+  private idSeq = 1;
+
+  findAll() {
+    return this.boards;
+  }
+
+  create(dto: CreateBoardDto) {
+    const board = { id: this.idSeq++, title: dto.title };
+    this.boards.push(board);
+    return board;
+  }
+}

--- a/trello-nest/src/boards/dto/create-board.dto.ts
+++ b/trello-nest/src/boards/dto/create-board.dto.ts
@@ -1,0 +1,3 @@
+export class CreateBoardDto {
+  title: string;
+}

--- a/trello-nest/src/cards/cards.controller.ts
+++ b/trello-nest/src/cards/cards.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Post, Body, Param } from '@nestjs/common';
+import { CardsService } from './cards.service';
+import { CreateCardDto } from './dto/create-card.dto';
+
+@Controller('boards/:boardId/columns/:columnId/cards')
+export class CardsController {
+  constructor(private readonly cardsService: CardsService) {}
+
+  @Get()
+  findAll(
+    @Param('boardId') boardId: number,
+    @Param('columnId') columnId: number,
+  ) {
+    return this.cardsService.findAll(Number(boardId), Number(columnId));
+  }
+
+  @Post()
+  create(
+    @Param('boardId') boardId: number,
+    @Param('columnId') columnId: number,
+    @Body() dto: CreateCardDto,
+  ) {
+    return this.cardsService.create(
+      Number(boardId),
+      Number(columnId),
+      dto,
+    );
+  }
+}

--- a/trello-nest/src/cards/cards.module.ts
+++ b/trello-nest/src/cards/cards.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CardsController } from './cards.controller';
+import { CardsService } from './cards.service';
+
+@Module({
+  controllers: [CardsController],
+  providers: [CardsService],
+})
+export class CardsModule {}

--- a/trello-nest/src/cards/cards.service.ts
+++ b/trello-nest/src/cards/cards.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { CreateCardDto } from './dto/create-card.dto';
+
+interface Card {
+  id: number;
+  boardId: number;
+  columnId: number;
+  title: string;
+}
+
+@Injectable()
+export class CardsService {
+  private cards: Card[] = [];
+  private idSeq = 1;
+
+  findAll(boardId: number, columnId: number) {
+    return this.cards.filter(
+      (c) => c.boardId === boardId && c.columnId === columnId,
+    );
+  }
+
+  create(boardId: number, columnId: number, dto: CreateCardDto) {
+    const card = {
+      id: this.idSeq++,
+      boardId,
+      columnId,
+      title: dto.title,
+    };
+    this.cards.push(card);
+    return card;
+  }
+}

--- a/trello-nest/src/cards/dto/create-card.dto.ts
+++ b/trello-nest/src/cards/dto/create-card.dto.ts
@@ -1,0 +1,3 @@
+export class CreateCardDto {
+  title: string;
+}

--- a/trello-nest/src/columns/columns.controller.ts
+++ b/trello-nest/src/columns/columns.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Post, Body, Param } from '@nestjs/common';
+import { ColumnsService } from './columns.service';
+import { CreateColumnDto } from './dto/create-column.dto';
+
+@Controller('boards/:boardId/columns')
+export class ColumnsController {
+  constructor(private readonly columnsService: ColumnsService) {}
+
+  @Get()
+  findAll(@Param('boardId') boardId: number) {
+    return this.columnsService.findAll(Number(boardId));
+  }
+
+  @Post()
+  create(
+    @Param('boardId') boardId: number,
+    @Body() dto: CreateColumnDto,
+  ) {
+    return this.columnsService.create(Number(boardId), dto);
+  }
+}

--- a/trello-nest/src/columns/columns.module.ts
+++ b/trello-nest/src/columns/columns.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ColumnsController } from './columns.controller';
+import { ColumnsService } from './columns.service';
+
+@Module({
+  controllers: [ColumnsController],
+  providers: [ColumnsService],
+  exports: [ColumnsService],
+})
+export class ColumnsModule {}

--- a/trello-nest/src/columns/columns.service.ts
+++ b/trello-nest/src/columns/columns.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { CreateColumnDto } from './dto/create-column.dto';
+
+@Injectable()
+export class ColumnsService {
+  private columns = [] as { id: number; boardId: number; title: string }[];
+  private idSeq = 1;
+
+  findAll(boardId: number) {
+    return this.columns.filter((c) => c.boardId === boardId);
+  }
+
+  create(boardId: number, dto: CreateColumnDto) {
+    const column = { id: this.idSeq++, boardId, title: dto.title };
+    this.columns.push(column);
+    return column;
+  }
+}

--- a/trello-nest/src/columns/dto/create-column.dto.ts
+++ b/trello-nest/src/columns/dto/create-column.dto.ts
@@ -1,0 +1,3 @@
+export class CreateColumnDto {
+  title: string;
+}

--- a/trello-nest/src/main.ts
+++ b/trello-nest/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+  console.log(`Application is running on: ${await app.getUrl()}`);
+}
+bootstrap();

--- a/trello-nest/tsconfig.json
+++ b/trello-nest/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2018",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  }
+}


### PR DESCRIPTION
## Summary
- add `trello-nest` with NestJS starter code
- include boards, columns and cards modules
- provide README instructions for running

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fb96d4fa883228faf64ee6e2ceee0